### PR TITLE
RRP-615: Not refused shares when on previous job_id

### DIFF
--- a/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
+++ b/protocols/v2/roles-logic-sv2/src/channel_logic/channel_factory.rs
@@ -1611,7 +1611,7 @@ impl ProxyExtendedChannelFactory {
             .ok_or(Error::ShareDoNotMatchAnyJob)?
             .0;
 
-        if referenced_job.job_id != m.job_id {
+        if referenced_job.job_id != m.job_id && referenced_job.job_id - 1 != m.job_id {
             let error = SubmitSharesError {
                 channel_id: m.channel_id,
                 sequence_number: m.sequence_number,


### PR DESCRIPTION
Перебрал несколько вариантов, остановился на самом простом и надежном (пока что) - просто сделал так, что мы принимаем и с предыдущим job_id (собственно, о чем Алексей и говорил) - это должно решить часть проблем, надо тестировать. Есть еще более продвинутый вариант (и возможно, мы к нему придем) - когда принимать не все предыдущие job_id, а только в определенном временном окне. Но я пока не нашел варианта реализации, чтобы не надо было править структуру Downstream, а править ее без особой нужды не хочется по понятным причинам )) это по сути стержень всего proxy. Короче, надо тестировать под нагрузкой а там видно будет. Лучше всего на cpuminer чтобы по 100 воркеров на ядро)))) Я потом еще локально тоже погоняю это под нагрузкой. 